### PR TITLE
[chore] gitignore에 운영체제 파일 무시 규칙 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,62 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk


### PR DESCRIPTION
## Overview
macOS와 Windows에서 자동 생성되는 운영체제 파일이
커밋에 포함되지 않도록 .gitignore 규칙을 추가한다.

기존에는 .DS_Store, Thumbs.db, Desktop.ini 같은
비개발 파일이 변경 내역에 섞여 PR 노이즈와 불필요한
충돌 가능성을 높였다. 저장소 이력을 깔끔하게 유지하기
위해 공통 OS 무시 규칙을 반영했다.

프로젝트 코드와 무관한 OS 메타데이터 파일을 제외해
협업 시 diff 가독성과 리뷰 효율을 개선했다.

## Changes
- Windows 관련 .gitignore 규칙 추가
- macOS 관련 .gitignore 규칙 추가

## Related Issue

## Test

## Screenshot (Optional)
