### PR TITLE
fix: 수정 이력 목록 조회 정렬 조건 추가

### DIFF
--- a/src/main/java/com/sprint/mission/hrbank/domain/changelog/service/ChangeLogService.java
+++ b/src/main/java/com/sprint/mission/hrbank/domain/changelog/service/ChangeLogService.java
@@ -118,10 +118,12 @@ public class ChangeLogService {
   // 목록 조회
   public CursorPageResponseChangeLogDto getChangeLogs(ChangeLogSearchRequest request) {
 
+    String sortProperty = request.sortField().equals("ipAddress") ? "ipAddress" : "createdAt";
+
     // 정렬 방향과 기준 설정 (기본값 : createdAt 내림차순)
     Sort sort = Sort.by(
         request.sortDirection()
-            .equalsIgnoreCase("asc") ? Direction.ASC : Direction.DESC, "createdAt");
+            .equalsIgnoreCase("asc") ? Direction.ASC : Direction.DESC, sortProperty);
 
     // 페이지 크기와 정렬 조건으로 Pageable 생성
     Pageable pageable = PageRequest.of(0, request.size(), sort);


### PR DESCRIPTION
## Overview
createdAt으로만 정렬되던 것을 ipAddress 정렬도 가능하도록 수정

## Changes

- sortField가 ipAddress면 ipAddress로, 아니면 createdAt으로 정렬하도록 수정

## Related Issue
Closes #80

## Test
- GET /api/change-logs?sortField=ipAddress 호출 후 ipAddress 기준 정렬 확인
- GET /api/change-logs?sortField=at 호출 후 createdAt 기준 정렬 확인

## Screenshot (Optional)