### PR TITLE
fix: PostgreSQL null 파라미터 타입 오류 수정

### DIFF
--- a/src/main/java/com/sprint/mission/hrbank/domain/changelog/repository/ChangeLogRepository.java
+++ b/src/main/java/com/sprint/mission/hrbank/domain/changelog/repository/ChangeLogRepository.java
@@ -20,7 +20,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
       // 사번 부분 일치
       + "AND (:memo IS NULL OR c.memo LIKE %:memo%) " // 메모 부분 일치
       + "AND (:ipAddress IS NULL OR c.ipAddress LIKE %:ipAddress%) "  // ip 부분 일치
-      + "AND (:type IS NULL OR c.type = CAST(:type AS string)) " // 유형 완전 일치
+      + "AND (:type IS NULL OR c.type = :type) " // 유형 완전 일치
       + "AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom) " // 시간 범위 ~부터
       + "AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)")
   // 시간 범위 ~까지


### PR DESCRIPTION
## Overview
PostgreSQL에서 Instant 파라미터 타입을 추론하지 못해 발생하는 오류 수정

## Changes

- atFrom, atTo 파라미터에 CAST(AS timestamp) 추가

## Related Issue
Closes #118

## Test
- GET /api/change-logs 호출 후 정상 응답 확인

## Screenshot (Optional)