### PR TITLE
fix: 수정 이력 목록 조회 type=ALL 처리 추가

### DIFF
--- a/src/main/java/com/sprint/mission/hrbank/domain/changelog/ChangeLogType.java
+++ b/src/main/java/com/sprint/mission/hrbank/domain/changelog/ChangeLogType.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.hrbank.domain.changelog;
 
 public enum ChangeLogType {
+  ALL,
   CREATED, // 직원 추가
   UPDATED, // 정보 수정
   DELETED  // 직원 삭제

--- a/src/main/java/com/sprint/mission/hrbank/domain/changelog/service/ChangeLogService.java
+++ b/src/main/java/com/sprint/mission/hrbank/domain/changelog/service/ChangeLogService.java
@@ -128,11 +128,12 @@ public class ChangeLogService {
 
     // 페이지 크기와 정렬 조건으로 Pageable 생성
     Pageable pageable = PageRequest.of(0, request.size(), sort);
+    ChangeLogType type = (request.type() == ChangeLogType.ALL) ? null : request.type();
 
     // 검색 조건과 커서(idAfter) 기반으로 이력 목록 조회
     Slice<ChangeLog> changeLogSlices = changeLogRepository.searchChangeLogs(
         request.employeeNumber(),
-        request.type(), request.memo(),
+        type, request.memo(),
         request.ipAddress(), request.atFrom(), request.atTo(), request.idAfter(),
         pageable);
 
@@ -143,7 +144,7 @@ public class ChangeLogService {
 
     // 검색 조건 기준 전체 건수 조회 (totalElements용, idAfter 제외)
     long totalElements = changeLogRepository.countByConditions(request.employeeNumber(),
-        request.type(),
+        type,
         request.memo(),
         request.ipAddress(), request.atFrom(), request.atTo());
 


### PR DESCRIPTION
## Overview
프론트에서 유형 전체 선택 시 type=ALL로 요청이 오는데
ChangeLogType에 ALL이 없어 400 오류가 발생하는 문제를 수정한다.

## Changes

- ChangeLogType에 ALL 추가
- 서비스에서 ALL이면 null로 변환하여 전체 조회 처리

## Related Issue
Closes #122

## Test
- GET /api/change-logs?type=ALL 호출 후 전체 이력 정상 반환 확인

## Screenshot (Optional)